### PR TITLE
Improve workout logging and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ A lightweight client-side web application for managing and viewing personalized 
 
    * Open `log.html` to record how much weight you lifted for each set.
 
-7. **Check your statistics**
+7. **View previous logs**
+
+   * Open `logs.html` to browse all of your saved entries.
+
+8. **Check your statistics**
 
    * Open `stats.html` to see the best weight you've logged for each exercise.
 

--- a/create.html
+++ b/create.html
@@ -14,6 +14,7 @@
     </header>
     <main class="container">
         <section class="create-container">
+            <form id="plan-form" novalidate>
             <div class="mb-3">
                 <label for="day-select" class="form-label">Day</label>
                 <select id="day-select" class="form-select">
@@ -37,18 +38,19 @@
 
             <div id="exercises"></div>
             <button type="button" id="add-exercise" class="btn btn-secondary btn-sm mt-2">Add Exercise</button>
-
             <div id="create-buttons" class="mt-3">
                 <button type="button" id="save-day" class="btn btn-primary">Save Day</button>
                 <button type="button" id="save-plan" class="btn btn-success ms-2">Save Plan</button>
             </div>
             <div id="status" class="status mt-3"></div>
 
+            </form>
             <a href="index.html" class="d-block mt-4">Back to Workout Planner</a>
         </section>
     </main>
     <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="create.js"></script>
 </body>
 </html>

--- a/create.js
+++ b/create.js
@@ -17,10 +17,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const saveDayBtn = document.getElementById('save-day');
     const savePlanBtn = document.getElementById('save-plan');
     const statusEl = document.getElementById('status');
+    const form = $('#plan-form');
 
     let selectedMuscles = [];
 
     const plan = {};
+    let exCounter = 0;
+
+    form.validate({
+        errorClass: 'is-invalid',
+        validClass: 'is-valid',
+        onkeyup: function(element) { $(element).valid(); }
+    });
 
     function updateMuscleButton() {
         muscleDropdownBtn.textContent = selectedMuscles.length ? selectedMuscles.join(', ') : 'Select Muscle Groups';
@@ -46,17 +54,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
     updateMuscleButton();
     function createExerciseRow(data = {}) {
+        exCounter++;
         const row = document.createElement('div');
         row.className = 'exercise-row';
         row.innerHTML = `
-            <input type="text" class="form-control ex-name" placeholder="Name" value="${data.name || ''}" required>
-            <input type="number" class="form-control ex-sets" placeholder="Sets" value="${data.sets || ''}" min="1" max="10" required>
-            <input type="text" class="form-control ex-reps" placeholder="Reps" value="${data.reps || ''}" pattern="\\d+(?:-\\d+)?" required>
-            <input type="number" class="form-control ex-rest" placeholder="Rest" value="${data.rest_sec || ''}" min="0" max="600">
-            <input type="text" class="form-control ex-superset" placeholder="Superset" value="${data.superset_with || ''}">
+            <input type="text" name="ex-name-${exCounter}" class="form-control ex-name" placeholder="Name" value="${data.name || ''}" required>
+            <input type="number" name="ex-sets-${exCounter}" class="form-control ex-sets" placeholder="Sets" value="${data.sets || ''}" min="1" max="10" required>
+            <input type="text" name="ex-reps-${exCounter}" class="form-control ex-reps" placeholder="Reps" value="${data.reps || ''}" pattern="\\d+(?:-\\d+)?" required>
+            <input type="number" name="ex-rest-${exCounter}" class="form-control ex-rest" placeholder="Rest" value="${data.rest_sec || ''}" min="0" max="600">
+            <input type="text" name="ex-superset-${exCounter}" class="form-control ex-superset" placeholder="Superset" value="${data.superset_with || ''}">
             <button type="button" class="btn btn-danger btn-sm remove-exercise">&times;</button>
         `;
         row.querySelector('.remove-exercise').addEventListener('click', () => row.remove());
+        $(row).find('input').on('input', function(){ $('#plan-form').validate().element(this); });
         return row;
     }
 
@@ -86,15 +96,7 @@ document.addEventListener('DOMContentLoaded', () => {
     daySelect.addEventListener('change', e => loadDay(e.target.value));
 
     saveDayBtn.addEventListener('click', () => {
-        let valid = true;
-        $('#exercises .exercise-row input').each(function () {
-            if (!this.checkValidity()) {
-                this.reportValidity();
-                valid = false;
-                return false;
-            }
-        });
-        if (!valid) return;
+        if (!form.valid()) return;
 
         const day = daySelect.value;
         const muscle = selectedMuscles.join(', ');
@@ -122,6 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     savePlanBtn.addEventListener('click', () => {
+        if (!form.valid()) return;
         if (Object.keys(plan).length === 0) {
             statusEl.textContent = 'Add at least one day before saving.';
             statusEl.className = 'status-error';

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
     <div class="text-center mt-4">
         <a href="create.html" class="btn btn-success me-2">Create a Custom Plan</a>
         <a href="log.html" class="btn btn-primary me-2">Log Workout</a>
+        <a href="logs.html" class="btn btn-warning me-2">View Logs</a>
         <a href="stats.html" class="btn btn-info">Statistics</a>
     </div>
 

--- a/log.js
+++ b/log.js
@@ -20,6 +20,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const saveBtn = document.getElementById('save-log');
   const statusEl = document.getElementById('log-status');
 
+  const params = new URLSearchParams(window.location.search);
+  const passedDay = parseInt(params.get('day'), 10);
+  const highlightExercise = params.get('exercise');
+
   const plan = JSON.parse(localStorage.getItem('workoutPlan') || '{}');
 
   function render(dateStr) {
@@ -44,6 +48,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 <span class="input-group-text">kg</span>
             </div>`;
       }
+      if (highlightExercise && ex.name === highlightExercise) {
+        exDiv.classList.add('border', 'border-primary');
+        setTimeout(() => exDiv.scrollIntoView({behavior: 'smooth'}), 0);
+      }
       container.appendChild(exDiv);
     });
 
@@ -60,8 +68,16 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  const today = new Date();
-  dateInput.valueAsDate = today;
+  function nextDateForDay(idx) {
+    const d = new Date();
+    while (d.getDay() !== idx) {
+      d.setDate(d.getDate() + 1);
+    }
+    return d;
+  }
+
+  const initialDate = (!isNaN(passedDay)) ? nextDateForDay(passedDay) : new Date();
+  dateInput.valueAsDate = initialDate;
   render(dateInput.value);
 
   dateInput.addEventListener('change', () => render(dateInput.value));

--- a/logs.html
+++ b/logs.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Workout Logs</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-light">
+<header class="bg-dark text-white text-center py-3 mb-4">
+    <h1>Logs</h1>
+</header>
+<main class="container">
+    <div id="logs-container"></div>
+    <a href="index.html" class="d-block mt-4">Back to Workout Planner</a>
+</main>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="logs.js"></script>
+</body>
+</html>

--- a/logs.js
+++ b/logs.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('logs-container');
+  const logs = JSON.parse(localStorage.getItem('workoutLogs') || '{}');
+  if (Object.keys(logs).length === 0) {
+    container.innerHTML = '<p class="text-center">No logs recorded.</p>';
+    return;
+  }
+  const table = document.createElement('table');
+  table.className = 'table table-sm';
+  table.innerHTML = '<thead><tr><th>Date</th><th>Exercise</th><th>Set</th><th>Weight (kg)</th></tr></thead><tbody></tbody>';
+  const tbody = table.querySelector('tbody');
+  Object.keys(logs).sort().forEach(date => {
+    const exs = logs[date].exercises || {};
+    Object.keys(exs).forEach(name => {
+      exs[name].forEach((w, idx) => {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${date}</td><td>${name}</td><td>${idx + 1}</td><td>${w ?? ''}</td>`;
+        tbody.appendChild(row);
+      });
+    });
+  });
+  container.appendChild(table);
+});

--- a/script.js
+++ b/script.js
@@ -19,7 +19,7 @@ const nextBtn = document.getElementById("next-day");
 
 let workoutsCache = null;
 
-function createExerciseEl({ name, sets, reps, rest_sec, superset_with }) {
+function createExerciseEl({ name, sets, reps, rest_sec, superset_with }, dayIdx) {
   const wrapper = document.createElement("div");
   wrapper.className = "exercise";
 
@@ -36,6 +36,12 @@ function createExerciseEl({ name, sets, reps, rest_sec, superset_with }) {
   `;
 
   wrapper.append(header, details);
+  wrapper.addEventListener('click', () => {
+    const url = new URL('log.html', window.location.href);
+    url.searchParams.set('day', dayIdx);
+    url.searchParams.set('exercise', name);
+    window.location.href = url.toString();
+  });
   return wrapper;
 }
 
@@ -71,7 +77,7 @@ function renderWorkout(dayIndex) {
 
   const fragment = document.createDocumentFragment();
   exercises.forEach(ex => {
-      fragment.appendChild(createExerciseEl(ex));
+      fragment.appendChild(createExerciseEl(ex, dayIndex));
   });
   containerEl.appendChild(fragment);
 }

--- a/style.css
+++ b/style.css
@@ -92,6 +92,7 @@ main {
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
     padding: 15px;
     transition: transform 0.2s ease-in-out;
+    cursor: pointer;
 }
 
 .exercise:hover {


### PR DESCRIPTION
## Summary
- add new `logs.html` page and helper script
- link exercises on the main page to the log page
- show View Logs link on index
- enable real-time form validation on the plan creator
- highlight clicked exercises in `log.html`
- add Bootstrap JS for dropdowns and pointer cursor styling
- document logs page in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845fb2bff4c8329a899949f2edba951